### PR TITLE
Fixed error when calling destory() on element containing dragtable.

### DIFF
--- a/src/js/jquery.dragtable.js
+++ b/src/js/jquery.dragtable.js
@@ -457,6 +457,8 @@
 		},
 				
 		destroy: function() {
+			var self = this,
+			o = self.options;
 			this.element.undelegate( 'thead th:not( :has(' + o.handle + ')), ' + o.handle, 'mousedown.' + self.widgetEventPrefix );
             
 		}


### PR DESCRIPTION
As Title says.
